### PR TITLE
Rely on Features.js for svg element creation.

### DIFF
--- a/client/src/components/shared/Features.js
+++ b/client/src/components/shared/Features.js
@@ -1,20 +1,37 @@
 import React from "react";
 import PropTypes from "prop-types";
 import SVG from "./SVG";
+import Path from "./Path";
 
 /**
- * Holds all interact-able elements of a rapid
+ * Holds all interact-able elements of a rapid. It should make an array of SVG elements to pass down.
  */
 
-const Features = ({ rapid, reducers, areHandlesVisible, areLinesVisible, areEddysVisible }) => {
+const Features = ({
+  rapid,
+  reducers,
+  areHandlesVisible,
+}) => {
   return (
-    <SVG
-      lines={areLinesVisible.value ? rapid.lines : []}
-      eddys={areEddysVisible.value ? rapid.eddys: []}
-      areHandlesVisible={areHandlesVisible}
-      reducers={reducers}
-      
-    />
+    <SVG reducers={reducers}>
+      {[
+        { features: rapid.lines, featureType: "line" },
+        { features: rapid.eddys, featureType: "eddy" },
+        //{ features: rapid.hydraulics, featureType: "hydraulic" },
+      ].map(({ features, featureType }, typeIndex) =>
+        features.map((feature, i) => (
+          <Path
+            line={feature.vector}
+            featureType={featureType}
+            typeIndex={typeIndex}
+            lineIndex={i}
+            reducers={reducers}
+            areHandlesVisible={areHandlesVisible}
+            key={feature.id}
+          />
+        ))
+      )}
+    </SVG>
   );
 };
 

--- a/client/src/components/shared/Path.js
+++ b/client/src/components/shared/Path.js
@@ -7,12 +7,22 @@ import Cubic from "./Cubic";
  * A line represents a safe route to navigate the river at a specific water level
  */
 
-const Path = ({ line, typeIndex, lineIndex, reducers, areHandlesVisible }) => {
+const Path = ({
+  line,
+  featureType,
+  lineIndex,
+  reducers,
+  areHandlesVisible,
+  typeIndex
+}) => {
   return (
     <>
       <path
-        className={typeIndex ? "eddy" : "line"}
-        d={buildPath({ points: line, closePath: typeIndex })}
+        className={featureType}
+        d={buildPath({
+          points: line,
+          closePath: featureType === "eddy" ? true : false,
+        })}
       />
       {areHandlesVisible.value &&
         line.map((p, i, a) => {

--- a/client/src/components/shared/SVG.js
+++ b/client/src/components/shared/SVG.js
@@ -1,9 +1,11 @@
 import React from "react";
 import { useSelector } from "react-redux";
 import { useMousePosition, useKeyPress } from "../shared/_utils";
-import Path from "./Path";
 
-const SVG = ({ lines, eddys, reducers, areHandlesVisible }) => {
+const SVG = ({
+  reducers,
+  children,
+}) => {
   const { draggedPoint, draggedCubic } = useSelector(
     (state) => state.testEnvironment
   );
@@ -20,45 +22,19 @@ const SVG = ({ lines, eddys, reducers, areHandlesVisible }) => {
   };
 
   return (
-    
-      <svg
-        className="svg-wrapper"
-        id="vector-container"
-        viewBox="0 0 100 100"
-        xmlns="http://www.w3.org/2000/svg"
-        preserveAspectRatio="none"
-        onMouseMove={() => handleMouseMove()}
-        onMouseUp={() => reducers.cancelDragging()}
-        onMouseDown={(e) => isCtrlPressed && reducers.addPoint({ coords })}
-        tabIndex="0"
-      >
-        <g>
-          {lines.map((line, i) => (
-            <Path
-              line={line.vector}
-              typeIndex={0}
-              lineIndex={i}
-              reducers={reducers}
-              areHandlesVisible={areHandlesVisible}
-              key={line.id}
-            />
-          ))}
-        </g>
-        <g>
-          {eddys.map((eddy, i) => (
-            <Path
-              line={eddy.vector}
-              typeIndex={1}
-              lineIndex={i}
-              reducers={reducers}
-              areHandlesVisible={areHandlesVisible}
-              key={eddy.id}
-            />
-          ))}
-        </g>
-      </svg>
-    
-    
+    <svg
+      className="svg-wrapper"
+      id="vector-container"
+      viewBox="0 0 100 100"
+      xmlns="http://www.w3.org/2000/svg"
+      preserveAspectRatio="none"
+      onMouseMove={() => handleMouseMove()}
+      onMouseUp={() => reducers.cancelDragging()}
+      onMouseDown={() => isCtrlPressed && reducers.addPoint({ coords })}
+      tabIndex="0"
+    >
+      {children}
+    </svg>
   );
 };
 


### PR DESCRIPTION
Just rearranged Features and SVG to eliminate some prop passing and use Features.js a bit better. I think this is kinda cool because our `<SVG />` is now a wrapper component just like a real HTML `<svg></svg>`. 

Its nothing serious, but made me realize that `typeIndex` is not a great way to differentiate between line/eddy/hydraulic because the order in which they are stored is kinda arbitrary. A better way is a string `featureType` its more meaningful. That same string can also be used to assign a className. 

I introduced `featureType` to assign a className but I didnt follow the implementation through to the reducers, and I also didnt get rid of any typeIndex stuff. 

This should be pretty basic, so if it makes sense, you can merge this PR into develop yourself. 