### PR TITLE
Features Separation and Logic

### DIFF
--- a/client/src/components/shared/Cubic.js
+++ b/client/src/components/shared/Cubic.js
@@ -1,6 +1,6 @@
 import React from "react";
 
-const Cubic = ({ typeIndex, lineIndex, pointIndex, reducers, ...props }) => {
+const Cubic = ({ featureType, lineIndex, pointIndex, reducers, ...props }) => {
   return (
     <g className="ad-Anchor">
       <line
@@ -23,7 +23,7 @@ const Cubic = ({ typeIndex, lineIndex, pointIndex, reducers, ...props }) => {
           reducers.setDraggedCubic({
             lineIndex,
             pointIndex,
-            typeIndex,
+            featureType,
             anchor: 0,
           })
         }
@@ -37,7 +37,7 @@ const Cubic = ({ typeIndex, lineIndex, pointIndex, reducers, ...props }) => {
           reducers.setDraggedCubic({
             lineIndex,
             pointIndex,
-            typeIndex,
+            featureType,
             anchor: 1,
           })
         }

--- a/client/src/components/shared/Eddy.js
+++ b/client/src/components/shared/Eddy.js
@@ -26,7 +26,21 @@ const Eddy = ({
       {areHandlesVisible.value &&
         line.map((p, i, a) => {
           let anchors = [];
-          if (p.z) {
+          const p2x = p.z ? a[0].x : p.x;
+          const p2y = p.z ? a[0].y : p.y;
+          const point = p.z ? null : (
+            <Point
+              featureType={featureType}
+              lineIndex={lineIndex}
+              pointIndex={i}
+              reducers={reducers}
+              x={p.x}
+              y={p.y}
+              key={i}
+            />
+          );
+
+          if (p.c) {
             anchors.push(
               <Cubic
                 featureType={featureType}
@@ -35,27 +49,8 @@ const Eddy = ({
                 reducers={reducers}
                 p1x={a[i - 1].x}
                 p1y={a[i - 1].y}
-                p2x={a[0].x}
-                p2y={a[0].y}
-                x1={p.c[0].x}
-                y1={p.c[0].y}
-                x2={p.c[1].x}
-                y2={p.c[1].y}
-                key={i}
-              />
-            );
-            return <React.Fragment key={i}>{anchors}</React.Fragment>;
-          } else if (p.c) {
-            anchors.push(
-              <Cubic
-                featureType={featureType}
-                lineIndex={lineIndex}
-                pointIndex={i}
-                reducers={reducers}
-                p1x={a[i - 1].x}
-                p1y={a[i - 1].y}
-                p2x={p.x}
-                p2y={p.y}
+                p2x={p2x}
+                p2y={p2y}
                 x1={p.c[0].x}
                 y1={p.c[0].y}
                 x2={p.c[1].x}
@@ -66,15 +61,7 @@ const Eddy = ({
           }
           return (
             <React.Fragment key={i}>
-              <Point
-                featureType={featureType}
-                lineIndex={lineIndex}
-                pointIndex={i}
-                reducers={reducers}
-                x={p.x}
-                y={p.y}
-                key={i}
-              />
+              {point}
               {anchors}
             </React.Fragment>
           );

--- a/client/src/components/shared/Eddy.js
+++ b/client/src/components/shared/Eddy.js
@@ -7,9 +7,9 @@ import Cubic from "./Cubic";
  * A line represents a safe route to navigate the river at a specific water level
  */
 
-const Path = ({
+const Eddy = ({
   line,
-  featureType,
+  featureType = "eddy",
   lineIndex,
   reducers,
   areHandlesVisible,
@@ -20,7 +20,7 @@ const Path = ({
         className={featureType}
         d={buildPath({
           points: line,
-          closePath: featureType === "eddy" ? true : false,
+          closePath: true,
         })}
       />
       {areHandlesVisible.value &&
@@ -83,4 +83,4 @@ const Path = ({
   );
 };
 
-export default Path;
+export default Eddy;

--- a/client/src/components/shared/Features.js
+++ b/client/src/components/shared/Features.js
@@ -1,31 +1,49 @@
 import React from "react";
 import PropTypes from "prop-types";
 import SVG from "./SVG";
-import Path from "./Path";
+import Line from "./Line";
+import Eddy from "./Eddy";
 
 /**
  * Holds all interact-able elements of a rapid. It should make an array of SVG elements to pass down.
  */
 
 const Features = ({ rapid, reducers, areHandlesVisible }) => {
+  const { lines, eddys, hydraulics } = rapid;
   return (
     <SVG reducers={reducers}>
-      {[
-        { features: rapid.lines, featureType: "line" },
-        { features: rapid.eddys, featureType: "eddy" },
-        //{ features: rapid.hydraulics, featureType: "hydraulic" },
-      ].map(({ features, featureType }) =>
-        features.map((feature, i) => (
-          <Path
-            line={feature.vector}
-            featureType={featureType}
-            lineIndex={i}
-            reducers={reducers}
-            areHandlesVisible={areHandlesVisible}
-            key={feature.id}
-          />
-        ))
-      )}
+      {[lines, eddys, hydraulics].map((features) => {
+        switch (features) {
+          // LINES
+          case lines:
+            return features.map((line, i) => (
+              <Line
+                line={line.vector}
+                lineIndex={i}
+                reducers={reducers}
+                areHandlesVisible={areHandlesVisible}
+                key={line.id}
+              />
+            ));
+          // EDDYS
+          case eddys:
+            return features.map((eddy, i) => (
+              <Eddy
+                line={eddy.vector}
+                lineIndex={i}
+                reducers={reducers}
+                areHandlesVisible={areHandlesVisible}
+                key={eddy.id}
+              />
+            ));
+          // HYDRAULICS
+          case hydraulics:
+            console.log("Gotta make <Hydraulics />");
+            break;
+          default:
+            console.log("And many more");
+        }
+      })}
     </SVG>
   );
 };

--- a/client/src/components/shared/Features.js
+++ b/client/src/components/shared/Features.js
@@ -8,40 +8,28 @@ import Eddy from "./Eddy";
  * Holds all interact-able elements of a rapid. It should make an array of SVG elements to pass down.
  */
 
-const Features = ({ rapid, reducers, areHandlesVisible }) => {
-  const { lines, eddys /*hydraulics*/ } = rapid;
+const Features = ({ rapid, reducers, areHandlesVisible, areLinesVisible, areEddysVisible }) => {
+  const { lines, eddys } = rapid;
   return (
     <SVG reducers={reducers}>
-      {[lines, eddys /*hydraulics*/].map((features) => {
-        switch (features) {
-          // LINES
-          case lines:
-            return features.map((line, i) => (
-              <Line
-                line={line.vector}
-                lineIndex={i}
-                reducers={reducers}
-                areHandlesVisible={areHandlesVisible}
-                key={line.id}
-              />
-            ));
-          // EDDYS
-          case eddys:
-            return features.map((eddy, i) => (
-              <Eddy
-                line={eddy.vector}
-                lineIndex={i}
-                reducers={reducers}
-                areHandlesVisible={areHandlesVisible}
-                key={eddy.id}
-              />
-            ));
-          // HYDRAULICS
-          default:
-            console.log("And many more");
-            return null;
-        }
-      })}
+      {areLinesVisible.value && lines.map((line, i) => (
+        <Line
+          line={line.vector}
+          lineIndex={i}
+          reducers={reducers}
+          areHandlesVisible={areHandlesVisible}
+          key={line.id}
+        />
+      ))}
+      {areEddysVisible.value && eddys.map((eddy, i) => (
+        <Eddy
+          line={eddy.vector}
+          lineIndex={i}
+          reducers={reducers}
+          areHandlesVisible={areHandlesVisible}
+          key={eddy.id}
+        />
+      ))}
     </SVG>
   );
 };

--- a/client/src/components/shared/Features.js
+++ b/client/src/components/shared/Features.js
@@ -39,6 +39,7 @@ const Features = ({ rapid, reducers, areHandlesVisible }) => {
           // HYDRAULICS
           default:
             console.log("And many more");
+            return null;
         }
       })}
     </SVG>

--- a/client/src/components/shared/Features.js
+++ b/client/src/components/shared/Features.js
@@ -9,10 +9,10 @@ import Eddy from "./Eddy";
  */
 
 const Features = ({ rapid, reducers, areHandlesVisible }) => {
-  const { lines, eddys, hydraulics } = rapid;
+  const { lines, eddys /*hydraulics*/ } = rapid;
   return (
     <SVG reducers={reducers}>
-      {[lines, eddys, hydraulics].map((features) => {
+      {[lines, eddys /*hydraulics*/].map((features) => {
         switch (features) {
           // LINES
           case lines:
@@ -37,9 +37,6 @@ const Features = ({ rapid, reducers, areHandlesVisible }) => {
               />
             ));
           // HYDRAULICS
-          case hydraulics:
-            console.log("Gotta make <Hydraulics />");
-            break;
           default:
             console.log("And many more");
         }

--- a/client/src/components/shared/Features.js
+++ b/client/src/components/shared/Features.js
@@ -7,23 +7,18 @@ import Path from "./Path";
  * Holds all interact-able elements of a rapid. It should make an array of SVG elements to pass down.
  */
 
-const Features = ({
-  rapid,
-  reducers,
-  areHandlesVisible,
-}) => {
+const Features = ({ rapid, reducers, areHandlesVisible }) => {
   return (
     <SVG reducers={reducers}>
       {[
         { features: rapid.lines, featureType: "line" },
         { features: rapid.eddys, featureType: "eddy" },
         //{ features: rapid.hydraulics, featureType: "hydraulic" },
-      ].map(({ features, featureType }, typeIndex) =>
+      ].map(({ features, featureType }) =>
         features.map((feature, i) => (
           <Path
             line={feature.vector}
             featureType={featureType}
-            typeIndex={typeIndex}
             lineIndex={i}
             reducers={reducers}
             areHandlesVisible={areHandlesVisible}

--- a/client/src/components/shared/Line.js
+++ b/client/src/components/shared/Line.js
@@ -1,0 +1,67 @@
+import React from "react";
+import { buildPath } from "./_utils";
+import Point from "./Point";
+import Cubic from "./Cubic";
+
+/**
+ * A line represents a safe route to navigate the river at a specific water level
+ */
+
+const Line = ({
+  line,
+  featureType = "line",
+  lineIndex,
+  reducers,
+  areHandlesVisible,
+}) => {
+  return (
+    <>
+      <path
+        className={featureType}
+        d={buildPath({
+          points: line,
+          closePath: false,
+        })}
+      />
+      {areHandlesVisible.value &&
+        line.map((p, i, a) => {
+          let anchors = [];
+          if (p.c) {
+            anchors.push(
+              <Cubic
+                featureType={featureType}
+                lineIndex={lineIndex}
+                pointIndex={i}
+                reducers={reducers}
+                p1x={a[i - 1].x}
+                p1y={a[i - 1].y}
+                p2x={p.x}
+                p2y={p.y}
+                x1={p.c[0].x}
+                y1={p.c[0].y}
+                x2={p.c[1].x}
+                y2={p.c[1].y}
+                key={i}
+              />
+            );
+          }
+          return (
+            <React.Fragment key={i}>
+              <Point
+                featureType={featureType}
+                lineIndex={lineIndex}
+                pointIndex={i}
+                reducers={reducers}
+                x={p.x}
+                y={p.y}
+                key={i}
+              />
+              {anchors}
+            </React.Fragment>
+          );
+        })}
+    </>
+  );
+};
+
+export default Line;

--- a/client/src/components/shared/Path.js
+++ b/client/src/components/shared/Path.js
@@ -13,7 +13,6 @@ const Path = ({
   lineIndex,
   reducers,
   areHandlesVisible,
-  typeIndex
 }) => {
   return (
     <>
@@ -30,6 +29,7 @@ const Path = ({
           if (p.z) {
             anchors.push(
               <Cubic
+                featureType={featureType}
                 lineIndex={lineIndex}
                 pointIndex={i}
                 reducers={reducers}
@@ -48,7 +48,7 @@ const Path = ({
           } else if (p.c) {
             anchors.push(
               <Cubic
-                typeIndex={typeIndex}
+                featureType={featureType}
                 lineIndex={lineIndex}
                 pointIndex={i}
                 reducers={reducers}
@@ -67,7 +67,7 @@ const Path = ({
           return (
             <React.Fragment key={i}>
               <Point
-                typeIndex={typeIndex}
+                featureType={featureType}
                 lineIndex={lineIndex}
                 pointIndex={i}
                 reducers={reducers}

--- a/client/src/components/shared/Point.js
+++ b/client/src/components/shared/Point.js
@@ -8,7 +8,7 @@ import { useKeyPress } from "../shared/_utils";
  * @param {number} y - The y coord position of the point on a 100x100 layout.
  */
 
-const Point = ({ typeIndex, lineIndex, x, y, pointIndex, reducers }) => {
+const Point = ({ featureType, lineIndex, x, y, pointIndex, reducers }) => {
   const isCtrlPressed = useKeyPress("Control");
   return (
     <circle
@@ -16,7 +16,7 @@ const Point = ({ typeIndex, lineIndex, x, y, pointIndex, reducers }) => {
       onMouseDown={(e) => {
         isCtrlPressed
           ? reducers.removePoint({ lineIndex, pointIndex })
-          : reducers.setDraggedPoint({ lineIndex, pointIndex, typeIndex });
+          : reducers.setDraggedPoint({ lineIndex, pointIndex, featureType });
         e.stopPropagation();
       }}
       cx={x}

--- a/client/src/rematch/models.js
+++ b/client/src/rematch/models.js
@@ -222,14 +222,14 @@ export const testEnvironment = {
   },
   reducers: {
     setDraggedPoint: (state, payload) => {
-      state.activeType = payload.typeIndex;
+      state.activeType = payload.featureType;
       state.activeLine = payload.lineIndex;
       state.activePoint = payload.pointIndex;
       state.draggedPoint = true;
       return state;
     },
     setDraggedCubic: (state, payload) => {
-      state.activeType = payload.typeIndex;
+      state.activeType = payload.featureType;
       state.activeLine = payload.lineIndex;
       state.activePoint = payload.pointIndex;
       state.draggedCubic = payload.anchor;
@@ -238,7 +238,14 @@ export const testEnvironment = {
     setPointCoords: (state, payload) => {
       const activePoint = state.activePoint;
       const activeLine = state.activeLine;
-      const target = state.activeType === 0 ? state.lines : state.eddys;
+      const target =
+        state.activeType === "line"
+          ? state.lines
+          : state.activeType === "eddy"
+          ? state.eddys
+          : state.activeType === "hydraulic"
+          ? state.hydraulics
+          : "";
       target[activeLine].vector[activePoint].x = payload.coords.x;
       target[activeLine].vector[activePoint].y = payload.coords.y;
       return state;
@@ -246,7 +253,14 @@ export const testEnvironment = {
     setCubicCoords: (state, payload) => {
       const activePoint = state.activePoint;
       const activeLine = state.activeLine;
-      const target = state.activeType === 0 ? state.lines : state.eddys;
+      const target =
+        state.activeType === "line"
+          ? state.lines
+          : state.activeType === "eddy"
+          ? state.eddys
+          : state.activeType === "hydraulic"
+          ? state.hydraulics
+          : "";
       target[activeLine].vector[activePoint].c[payload.anchor].x =
         payload.coords.x;
       target[activeLine].vector[activePoint].c[payload.anchor].y =


### PR DESCRIPTION
1. Got rid of `typeIndex` and replaced it with `featureType`.
>Reducers refer to `featureType` when dispatching.
>It is declared inside the corresponding component.

2. Created `<Line />` and `<Eddy />` by separating `<Path />`
>Both are refactored.
>Each has it's essential variables hardcoded: `closePath`, `featureType`

3. Edited  `<Features />` to handle data with `switch/case`